### PR TITLE
Highlight over multi-line comments

### DIFF
--- a/serp.vim
+++ b/serp.vim
@@ -13,6 +13,7 @@ endif
 
 " comments, TODO's , and quotes
 syn match   serpComment	"%.*$" contains=serpTodo,@Spell
+syn region  serpComment start="/\*" end="\*/"
 syn keyword serpTodo FIXME NOTE TODO XXX contained
 syn region  serpString matchgroup=serpQuotes
       \ start=+[uU]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"


### PR DESCRIPTION
Extended the serpComment group to match start/end of the C-style comments, 
```
/*
muli
line comment
here */
```
![2018-07-02-104830_620x345_scrot](https://user-images.githubusercontent.com/19477741/42171228-c0c6bde4-7de6-11e8-9efb-c65e60dec775.png)

P.S.
this is wonderful :100: :trophy: 