### PR TITLE
Depletion, Sensitivity, and energy groups

### DIFF
--- a/serp.vim
+++ b/serp.vim
@@ -52,6 +52,10 @@ syn keyword serpGeom sqc px py pz plane cylx cyly cylz cyl cylv sph cone quadrat
 			\ inf tox toy torz rect hexxc hexyc hexxprism hexyprism octa dode
 			\ cube cuboid ppd pad cross gcross usr
 
+syn keyword serpEneGroups default2 defaultmg nj2 nj3 nj4 nj5 nj8 nj9 nj11 nj14 
+			\ nj16 nj17 nj18 nj19 nj20 nj21 nj22 nj23 wms69 wms172 cas70 cas40
+			\ cas25 cas23 cas18 cas16 cas14 cas12 cas9 cas8 cas7 cas4 cas3 cas2
+			\ mupo43 scale44 scale238
 syn keyword serpPreproc include
 
 let b:current_syntax = "serp"
@@ -63,6 +67,7 @@ hi def link serpTodo      Todo
 hi def link serpComment   Comment
 hi def link serpPreproc   PreProc
 hi def link serpGeom      Identifier
+hi def link serpEneGroups Identifier
 hi def link serpIsotope   Type
 hi def link serpScatter   Type
 

--- a/serp.vim
+++ b/serp.vim
@@ -48,17 +48,28 @@ syn keyword serpSet acelib adf alb arr bc blockdt bralib ccmaxiter ccmaxpop
 syn keyword serpStatement branch cell coef det div ftrans fun ifc lat mat mesh
 			\ particle pin plot solid src strans surf therm thermstoch
 			\ tme trans transv transa utrans wwgen wwin set
-			\ dep
+			\ sens dep
 
 " geometry
 syn keyword serpGeom sqc px py pz plane cylx cyly cylz cyl cylv sph cone quadratic
 			\ inf tox toy torz rect hexxc hexyc hexxprism hexyprism octa dode
 			\ cube cuboid ppd pad cross gcross usr
 
+" sensitivity settings
+" Keywords that directly follow sens
+syn keyword serpSensOpts resp opt pert latgen direct
+
+" Keywords that follow sensitivity options, e.g. responses
+" usage: sens opt egrid <> // sens resp keff [1/0]
+syn keyword serpSensArgs detratio egrid xs chi nubar eleg zailist matlist keff
+			\ leff beff void custom history
+
+" Pre-defined energy group structures
 syn keyword serpEneGroups default2 defaultmg nj2 nj3 nj4 nj5 nj8 nj9 nj11 nj14 
 			\ nj16 nj17 nj18 nj19 nj20 nj21 nj22 nj23 wms69 wms172 cas70 cas40
 			\ cas25 cas23 cas18 cas16 cas14 cas12 cas9 cas8 cas7 cas4 cas3 cas2
 			\ mupo43 scale44 scale238
+
 syn keyword serpPreproc include
 
 " Some special keywords that have special meaning in SERPENT
@@ -67,12 +78,14 @@ syn keyword serpSpecial outside sum all CE CELI LE LELI LEQI
 let b:current_syntax = "serp"
 hi def link serpStatement Statement
 hi def link serpSet       Special
+hi def link serpSensOpts  Special
 hi def link serpNumber    Number
 hi def link serpString    String
 hi def link serpTodo      Todo
 hi def link serpComment   Comment
 hi def link serpPreproc   PreProc
 hi def link serpGeom      Identifier
+hi def link serpSensArgs  Identifier
 hi def link serpEneGroups Identifier
 hi def link serpSpecial   Identifier
 hi def link serpIsotope   Type

--- a/serp.vim
+++ b/serp.vim
@@ -40,9 +40,10 @@ syn keyword serpSet acelib adf alb arr bc blockdt bralib ccmaxiter ccmaxpop
 			\ nphys nps outp poi pop ppid ppw relfactor rfr rfw rgb
 			\ root sacesrc seed spd sfylib title tcut tpa transnorm
 			\ trc ures usym opti power pcc dx dy dz ene dr
+			\ mdep de dm du dh dc tmp tft rgb vol burn flux
 			\ sw sc sm sp sx sy sz ss sd se sb sr st sf si sg
 			\ sie powdens daystep daytot bustep butot decstep dectot
-			\ depmtx
+			\ depmtx repro moder
 
 " some other statements
 syn keyword serpStatement branch cell coef det div ftrans fun ifc lat mat mesh

--- a/serp.vim
+++ b/serp.vim
@@ -41,11 +41,14 @@ syn keyword serpSet acelib adf alb arr bc blockdt bralib ccmaxiter ccmaxpop
 			\ root sacesrc seed spd sfylib title tcut tpa transnorm
 			\ trc ures usym opti power pcc dx dy dz ene dr
 			\ sw sc sm sp sx sy sz ss sd se sb sr st sf si sg
+			\ sie powdens daystep daytot bustep butot decstep dectot
+			\ depmtx
 
 " some other statements
 syn keyword serpStatement branch cell coef det div ftrans fun ifc lat mat mesh
 			\ particle pin plot solid src strans surf therm thermstoch
 			\ tme trans transv transa utrans wwgen wwin set
+			\ dep
 
 " geometry
 syn keyword serpGeom sqc px py pz plane cylx cyly cylz cyl cylv sph cone quadratic
@@ -58,6 +61,9 @@ syn keyword serpEneGroups default2 defaultmg nj2 nj3 nj4 nj5 nj8 nj9 nj11 nj14
 			\ mupo43 scale44 scale238
 syn keyword serpPreproc include
 
+" Some special keywords that have special meaning in SERPENT
+syn keyword serpSpecial outside sum all CE CELI LE LELI LEQI
+
 let b:current_syntax = "serp"
 hi def link serpStatement Statement
 hi def link serpSet       Special
@@ -68,6 +74,7 @@ hi def link serpComment   Comment
 hi def link serpPreproc   PreProc
 hi def link serpGeom      Identifier
 hi def link serpEneGroups Identifier
+hi def link serpSpecial   Identifier
 hi def link serpIsotope   Type
 hi def link serpScatter   Type
 

--- a/serp.vim
+++ b/serp.vim
@@ -40,6 +40,7 @@ syn keyword serpSet acelib adf alb arr bc blockdt bralib ccmaxiter ccmaxpop
 			\ nphys nps outp poi pop ppid ppw relfactor rfr rfw rgb
 			\ root sacesrc seed spd sfylib title tcut tpa transnorm
 			\ trc ures usym opti power pcc dx dy dz ene dr
+			\ sw sc sm sp sx sy sz ss sd se sb sr st sf si sg
 
 " some other statements
 syn keyword serpStatement branch cell coef det div ftrans fun ifc lat mat mesh


### PR DESCRIPTION
Wide-ranging PR. I've tried to separate and explain each commit.

Major changes are documented here

* Added new match group for [per-defined energy grids](http://serpent.vtt.fi/mediawiki/index.php/Pre-defined_energy_group_structures)
![ene](https://user-images.githubusercontent.com/19477741/42714786-4f264ad0-86c2-11e8-814f-a872caef154b.png)
* Added some depletion-specific settings, like step settings e.g. `dep daystep 0.1` and scheme `set pcc LELI`
* Added two new match groups to support sensitivity parameters
![2018-07-13-172810_246x134_scrot](https://user-images.githubusercontent.com/19477741/42714806-61367574-86c2-11e8-9e96-6a697523e243.png)
